### PR TITLE
update

### DIFF
--- a/Day-1/04-quantification.md
+++ b/Day-1/04-quantification.md
@@ -13,23 +13,23 @@ cd results/quant
 ```
 
 ## Principle of quantifying read counts for RNA-seq 
-For most downstream analyses in RNA-seq, especially differential expression, we care about how many reads aligned to a specific gene, as this tells us about its expression level, which we can then compare to other samples. Inherently, this means that we want to make these data *count-based*, so that we can use statistical models to compare these counts between our experimental conditions of interest. 
+For most downstream analyses in RNA-seq, especially differential expression, we care about how many reads aligned to a specific gene, as this tells us about the genes expression level, which we can then compare to other samples. Inherently, this means that we want to make these data *count-based*, so that we can use statistical models to compare these counts between experimental conditions of interest. 
 
 ![](../figures/quant_principle.png)
 
-There are a number of methods that one can use to quantify reads overlapping a specific features ( in this case, exons). These methods require a .bam file as input, in addition to a list of the genomic features that we wish to count reads over. The most simplistic methods (e.g. [htseq-count](https://htseq.readthedocs.io/en/release_0.11.1/count.html), [featureCounts](http://subread.sourceforge.net/)) use a specific set of rules to count the number of reads overlapping specific features. These are a good choice if your data is less complex, e.g. 3'-end data. 
+There are a number of methods that one can use to quantify reads overlapping specific features ( in this case, exons). These methods require a .bam file as input, in addition to a list of the genomic features that we wish to count reads over. The most simplistic methods (e.g. [htseq-count](https://htseq.readthedocs.io/en/release_0.11.1/count.html), [featureCounts](http://subread.sourceforge.net/)) use a specific set of rules to count the number of reads overlapping specific features. These are a good choice if your data is less complex, e.g. 3'-end data. 
 
 Other methods leverage probablistic modeling in order to quantify the alignments (e.g. [RSEM](https://deweylab.github.io/RSEM/)), which ascibes reads to features with a probability of this being the correct location for a given read. Generally, these methods are used on more complex data (e.g. full-length transcript and/or paired-end data) where transcript estimates are of interest. 
 
-For our analysis, we will used htseq-count. htseq-count has three distinct modes for handling overlapping features; union, intersection_strict, and intersection_nonempty. You change change these using the `mode` option. The behavious of each setting is described in the figure below, taken from the htseq-count documnetation. Another important (and related) behaviour of htseq-count is how it handles multi-mapping reads (reads that map to > 1 place in the genome). Generally, multimapping reads are discarded during counting to prevent introduction of bias into the counts. 
+For our analysis, we will used htseq-count. htseq-count has three distinct modes for handling overlapping features; union, intersection_strict, and intersection_nonempty. You change change these using the `mode` option. The behaviour of each setting is described in the figure below, taken from the htseq-count documentation. Another important (and related) behaviour of htseq-count is how it handles multi-mapping reads (reads that map to > 1 place in the genome). Generally, multimapping reads are discarded during counting to prevent introduction of bias into the counts. 
 
 # Counting modes (from the htseq-count documentation, found [here](https://htseq.readthedocs.io/en/release_0.11.1/count.html))
 
 ![](../figures/htseq-count-mode.png)
 
-One of the most important options in htseq-count is `strandedness`. It is critical to select the correct option for `strandedness` (`-s`) for your dataset, otherwise you may incorrectly use, or throw away, a lot of information. The default setting in htseq-count for `strandedness` is `yes`. This means reads will only be counted as overlapping a feature provided they map to the same strand as the feature. If you data was generated using an unstranded library preparation protocol, as in this experiment, we must set this option to `no`. Failiure to do so would mean you would throw away ~50% of all your reads, as they will be distributed equally across both strands for each feature in an unstranded library.  
+One of the most important options in htseq-count is `strandedness`. It is critical to select the correct option for `strandedness` (`-s`) for your dataset, otherwise you may incorrectly use, or throw away, a lot of information. The default setting in htseq-count for `strandedness` is `yes`. This means reads will only be counted as overlapping a feature provided they map to the same strand as the feature. If your data was generated using an unstranded library preparation protocol, as in this experiment, we must set this option to `no`. Failiure to do so would mean you would throw away ~50% of all your reads, as they will be distributed equally across both strands for each feature in an unstranded library.  
 
-Another important important option in htseq-count is `t` or `type` which specifies which feature type (3rd column of a GTF file) you want to count features over. The default is `exon` which works for GTF files from Ensembl, such as the file we will be using. However, this can be changed to any feature in your GTF file, so theoretically can be used to count any feature you have annotated. 
+Another important option in htseq-count is `t` or `type` which specifies which feature type (3rd column of a GTF file) you want to count features over. The default is `exon` which works for GTF files from Ensembl, such as the file we will be using. However, this can be changed to any feature in your GTF file, so theoretically can be used to count any feature you have annotated. 
 
 When counting paired-end data (such as in this experiemnt) your .bam files should be sorted before running htseq-count, and you can specify how your .bam is sorted using the `-r` option. `name` indicates they are sorted by read name, `pos` indicates they are sorted by genomic position. 
 
@@ -91,7 +91,7 @@ The final step in the pre-processing of RNA-seq data for differential expression
 
 
 
-Have a look at the htseq-count output files 
+Have a look at the htseq-count output files ran on the entire dataset (rather than the subset we have been practicing with)
 ```bash
 ls /dartfs-hpc/scratch/rnaseq1/data/htseq-count/
 ```
@@ -115,7 +115,7 @@ myarray=()
 while read x;  do
 	# split up sample names to remove everything after "_"
 	sname=`echo "$x"`
-	sname=`echo "$sname" | cut -d"." -f1`
+	sname=`echo "$sname" | cut -d"_" -f1`
 	# extract second column of file to get read counts only 
 	echo counts for "$sname" being extracted
 	cut -f2 $x > "$sname".tmp.counts
@@ -129,7 +129,7 @@ This will take a few minutes..
 
 Paste all gene IDs into a file with each to make the gene expression matrix
 ```bash 
-cut -f1 SRR1039508.htseq-counts > gene_IDs.txt
+cut -f1 SRR1039508_1.htseq-counts > gene_IDs.txt
 paste gene_IDs.txt *.tmp.counts > tmp_all_counts.txt
 head tmp_all_counts.txt 
 ```
@@ -164,7 +164,7 @@ Remove all the tmp files
 rm -f *tmp*
 ```
 
-In practice, you would have generated the a `.htseq.counts` file using all genes accross the entire genome, and using all of the samples in the dataset, instead of the four samples we used in these examples. So that we have the complete set of counts available for day 2, we have made a complete raw counts matrix for you to use. You can find this in `/dartfs-hpc/scratch/rnaseq1/data/htseq-counts/`. It is also is the GitHub repo that you downloaded in the `Day-2` folder, as we will be loading it into `R` tomorrow for the differential expression analysis. 
+In practice, you would have generated the `.htseq.counts` files using all genes accross the entire genome, and using all of the samples in the dataset, instead of the four samples we used in these examples. So that we have the complete set of counts available for day 2, we have made a complete raw counts matrix for you to use. You can find this in `/dartfs-hpc/scratch/rnaseq1/data/htseq-counts/`. It is also is the GitHub repository that you downloaded in the `Day-2` folder, as we will be loading it into `R` tomorrow for the differential expression analysis. 
 
 ```bash 
 head /dartfs-hpc/scratch/rnaseq1/data/htseq-count/all_counts.txt


### PR DESCRIPTION
fixed a couple of typos and changed the cut command on line 118 to cut on the "_" instead of the "." so that sample names dropped the _1 at the end of the name just a stylistic thing but from the comments this is what you had intended.